### PR TITLE
Remove space from 'alt=' tag value.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -102,7 +102,7 @@ function writeMath(mathTxt, inLine) {
     // store svg in a file
     fs.writeFileSync(fileName, svgCode);
 
-    let alt = `alt=" "`;
+    let alt = `alt=""`;
     // if display mode mathTxt can include inline tags
     // replace by $ to avoid processing them later
     // use $$, $ has special meaning in replace()


### PR DESCRIPTION
I suspect it may have been to avoid ebookmaker warnings, but this is undesirable, it ignores a valid issue.